### PR TITLE
fix: whatis and shortdescription

### DIFF
--- a/mango.go
+++ b/mango.go
@@ -46,7 +46,7 @@ func NewManPage(section uint, title string, description string) *ManPage {
 	return &ManPage{
 		Root:        *root,
 		section:     section,
-		description: description,
+		description: title + " - " + description,
 	}
 }
 


### PR DESCRIPTION
According to lintian, it seems the `SH` section should begin with the command name, then a ` - `, then its actual short description.

this is apparently used by `whatis`.

closes https://github.com/muesli/mango-coral/pull/1