### PR TITLE
fix: formatting of short flags when PFlag=true

### DIFF
--- a/mango.go
+++ b/mango.go
@@ -124,7 +124,7 @@ func (m ManPage) buildCommand(w Builder, c Command) {
 			}
 
 			if opt.Short != "" {
-				w.TextBold(fmt.Sprintf("%[1]s%[2]s %[1]s%[3]s", prefix, opt.Short, opt.Name))
+				w.TextBold(fmt.Sprintf("-%[2]s, %[1]s%[3]s", prefix, opt.Short, opt.Name))
 			} else {
 				w.TextBold(prefix + opt.Name)
 			}


### PR DESCRIPTION
Previously this was formatted as eg.

    --h --help

Now it will be:

    -h, --help