### PR TITLE
feat: add support for examples

### DIFF
--- a/mango.go
+++ b/mango.go
@@ -22,6 +22,7 @@ type Command struct {
 	Name     string
 	Short    string
 	Usage    string
+	Example  string
 	Flags    map[string]Flag
 	Commands map[string]*Command
 }
@@ -172,6 +173,24 @@ func (m ManPage) buildCommand(w Builder, c Command) {
 		}
 
 		if c.Name == m.Root.Name {
+		} else {
+			w.IndentEnd()
+		}
+	}
+
+	if c.Example != "" {
+		if c.Name == m.Root.Name {
+			w.Section("Examples")
+			w.TaggedParagraph(-1)
+		} else {
+			w.TaggedParagraph(-1)
+			w.TextBold("EXAMPLES")
+			w.Indent(4)
+		}
+		w.Text(c.Example)
+
+		if c.Name == m.Root.Name {
+			w.EndSection()
 		} else {
 			w.IndentEnd()
 		}


### PR DESCRIPTION
Some libraries like cobra allow you to set examples for commands. 
This PR extends the `mango.Command` with an example which will be added to the man page automatically. 

The placement of the examples is roughly according to https://linux.die.net/man/7/man-pages

An example implementation for a mango adapter can be found here: https://github.com/muesli/mango-cobra/compare/main...jon4hz:mango-cobra:main