### PR TITLE
chore: bump Go to 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [~1.12, ^1]
+        go-version: [~1.18, ^1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/muesli/mango
 
-go 1.17
+go 1.18
 
 require github.com/muesli/roff v0.1.0


### PR DESCRIPTION
Required for newer Go workflows.